### PR TITLE
Feature/money

### DIFF
--- a/src/api/exchangeApi.js
+++ b/src/api/exchangeApi.js
@@ -1,8 +1,14 @@
 const fetch = require('node-fetch');
 const InvalidArgumentError = require('../error/invalidArgumentError');
 
+/**
+ * tempo em minutos para persistencia dos dados de conversão monetária em cache
+ */
 const TIME_CACHE_MINUTES = 15;
 
+/**
+ * classe utilizada para fazer requisições de valores para conversões monetárias
+ */
 class ExchangeApi {
   constructor() {
     this._url = 'https://api.exchangeratesapi.io';
@@ -13,6 +19,9 @@ class ExchangeApi {
     this.MAX_AGE = TIME_CACHE_MINUTES * 60 * 1000;
   }
 
+  /**
+   * @returns instância da classe ExchangeApi para realização das consultas
+   */
   static getInstance() {
     if (!this._instance) {
       this._instance = new ExchangeApi();
@@ -20,17 +29,35 @@ class ExchangeApi {
     return this._instance;
   }
 
+  /**
+   * verifica se o valor guardado na cache é válido
+   * @param {object} cachedValue valor guardado na cache
+   * @returns boolean true caso for válido e false caso expirado
+   */
   _isCacheValid(cachedValue) {
     return cachedValue 
             && cachedValue.timestamp
             && new Date().getTime() - cachedValue.timestamp  > 0;
   }
 
+  /**
+   * verifica se a chave que será utilizada é válida na API
+   * @param {string} rate base para a conversão monetária
+   */
   _isValidRate(rate) {
     return ExchangeApi.ACCEPTED_RATES.includes(rate);
   }
 
-  async getCurrency(from, to) {
+  /**
+   * realiza uma requisição à api exchangeratesapi
+   * 
+   * @param {string} from moeda base para a consulta
+   * @param {string} to moeda alvo para a consulta
+   * 
+   * @returns os valores atuais
+   * @throws InvalidArgumentError no caso de algum dos parâmetros não for suportado pela API
+   */
+  async getExchange(from, to) {
     const key = `${from}-${to}`;
     const cached = this._cache[key];
     let data;
@@ -56,6 +83,9 @@ class ExchangeApi {
 
 }
 
+/**
+ * valores aceitos pela API exchangeratesapi
+ */
 ExchangeApi.ACCEPTED_RATES = [
   'CAD',
   'HKD',

--- a/src/api/exchangeApi.js
+++ b/src/api/exchangeApi.js
@@ -12,9 +12,9 @@ const TIME_CACHE_MINUTES = 15;
 class ExchangeApi {
   constructor() {
     this._url = 'https://api.exchangeratesapi.io';
-    
+
     this._cache = {};
-    
+
     // 15 minutes
     this.MAX_AGE = TIME_CACHE_MINUTES * 60 * 1000;
   }
@@ -35,9 +35,9 @@ class ExchangeApi {
    * @returns boolean true caso for válido e false caso expirado
    */
   _isCacheValid(cachedValue) {
-    return cachedValue 
-            && cachedValue.timestamp
-            && new Date().getTime() - cachedValue.timestamp  > 0;
+    return cachedValue
+      && cachedValue.timestamp
+      && new Date().getTime() - cachedValue.timestamp < this.MAX_AGE;
   }
 
   /**
@@ -64,7 +64,7 @@ class ExchangeApi {
 
     if (!this._isValidRate(from)) {
       throw new InvalidArgumentError(from);
-    } 
+    }
     if (!this._isValidRate(to)) {
       throw new InvalidArgumentError(to);
     }
@@ -76,6 +76,7 @@ class ExchangeApi {
 
     if (this._isCacheValid(cached)) {
       data = { ...cached, isCached: true };
+      console.log(new Date().getTime() - cached.timestamp) ;
     } else {
       const res = await fetch(`${this._url}/latest?base=${from}&symbols=${to}`)
       data = await res.json();

--- a/src/api/exchangeApi.js
+++ b/src/api/exchangeApi.js
@@ -1,0 +1,95 @@
+const fetch = require('node-fetch');
+const InvalidArgumentError = require('../error/invalidArgumentError');
+
+const TIME_CACHE_MINUTES = 15;
+
+class ExchangeApi {
+  constructor() {
+    this._url = 'https://api.exchangeratesapi.io';
+    
+    this._cache = {};
+    
+    // 15 minutes
+    this.MAX_AGE = TIME_CACHE_MINUTES * 60 * 1000;
+  }
+
+  static getInstance() {
+    if (!this._instance) {
+      this._instance = new ExchangeApi();
+    }
+    return this._instance;
+  }
+
+  _isCacheValid(cachedValue) {
+    return cachedValue 
+            && cachedValue.timestamp
+            && new Date().getTime() - cachedValue.timestamp  > 0;
+  }
+
+  _isValidRate(rate) {
+    return ExchangeApi.ACCEPTED_RATES.includes(rate);
+  }
+
+  async getCurrency(from, to) {
+    const key = `${from}-${to}`;
+    const cached = this._cache[key];
+    let data;
+
+    if (!this._isValidRate(from)) {
+      throw new InvalidArgumentError(from);
+    } 
+    if (!this._isValidRate(to)) {
+      throw new InvalidArgumentError(to);
+    }
+
+    if (this._isCacheValid(cached)) {
+      data = { ...cached, isCached: true };
+    } else {
+      const res = await fetch(`${this._url}/latest?base=${from}&symbols=${to}`)
+      data = await res.json();
+      data.timestamp = new Date().getTime();
+      this._cache[key] = data;
+    }
+
+    return data;
+  }
+
+}
+
+ExchangeApi.ACCEPTED_RATES = [
+  'CAD',
+  'HKD',
+  'ISK',
+  'PHP',
+  'DKK',
+  'HUF',
+  'CZK',
+  'GBP',
+  'RON',
+  'SEK',
+  'IDR',
+  'INR',
+  'BRL',
+  'RUB',
+  'HRK',
+  'JPY',
+  'THB',
+  'CHF',
+  'EUR',
+  'MYR',
+  'BGN',
+  'TRY',
+  'CNY',
+  'NOK',
+  'NZD',
+  'ZAR',
+  'USD',
+  'MXN',
+  'SGD',
+  'AUD',
+  'ILS',
+  'KRW',
+  'PLN'
+]
+
+module.exports = ExchangeApi;

--- a/src/api/exchangeApi.js
+++ b/src/api/exchangeApi.js
@@ -69,6 +69,11 @@ class ExchangeApi {
       throw new InvalidArgumentError(to);
     }
 
+    // anti troll
+    if (from === to) {
+      data = { rates: { [`${to}`]: 1 } };
+    }
+
     if (this._isCacheValid(cached)) {
       data = { ...cached, isCached: true };
     } else {

--- a/src/api/exchangeApi.js
+++ b/src/api/exchangeApi.js
@@ -76,7 +76,6 @@ class ExchangeApi {
 
     if (this._isCacheValid(cached)) {
       data = { ...cached, isCached: true };
-      console.log(new Date().getTime() - cached.timestamp) ;
     } else {
       const res = await fetch(`${this._url}/latest?base=${from}&symbols=${to}`)
       data = await res.json();

--- a/src/commands/Util/MoneyCommand.js
+++ b/src/commands/Util/MoneyCommand.js
@@ -39,7 +39,7 @@ class LeaveCommand extends Command {
     try {
       const res = await ExchangeApi.getInstance().getExchange(from.toUpperCase(), to.toUpperCase());
       const total = (res.rates[to] * parseFloat(ammount)).toFixed(2);
-      const totalFormated = Intl.NumberFormat('pt-BR', { style: 'currency', currency: to}).format(total)
+      const totalFormated = Intl.NumberFormat('pt-BR', { style: 'currency', currency: to}).format(total);
 
       message.chinoReply('success', moneybag + ' ' + t('commands:money.success', { from, to, ammount, total: totalFormated }));
     } catch (err) {

--- a/src/commands/Util/MoneyCommand.js
+++ b/src/commands/Util/MoneyCommand.js
@@ -15,7 +15,7 @@ class LeaveCommand extends Command {
     })
   }
   async run({ message, args, server }, t) {
-    let [ from, to, ammount = 1 ] = args;
+    let [from, to, ammount = 1] = args;
 
     const { moneybag } = this.client.emotes;
 
@@ -29,7 +29,7 @@ class LeaveCommand extends Command {
     }
 
     if (isNaN(ammount)) {
-      message.chinoReply('error',t('command:money.invalidValue'))
+      message.chinoReply('error', t('command:money.invalidValue'))
       return;
     }
 
@@ -39,12 +39,12 @@ class LeaveCommand extends Command {
     try {
       const res = await ExchangeApi.getInstance().getExchange(from.toUpperCase(), to.toUpperCase());
       const total = (res.rates[to] * parseFloat(ammount)).toFixed(2);
-      const totalFormated = Intl.NumberFormat('pt-BR', { style: 'currency', currency: to}).format(total);
+      const totalFormated = Intl.NumberFormat('pt-BR', { style: 'currency', currency: to }).format(total);
 
       message.chinoReply('success', moneybag + ' ' + t('commands:money.success', { from, to, ammount, total: totalFormated }));
     } catch (err) {
       if (err instanceof InvalidArgumentError) {
-        message.chinoReply('error',t('commands:money.invalidArgument', { arg: err.message }));
+        message.chinoReply('error', t('commands:money.invalidArgument', { arg: err.message }));
       }
     }
   }

--- a/src/commands/Util/MoneyCommand.js
+++ b/src/commands/Util/MoneyCommand.js
@@ -39,8 +39,9 @@ class LeaveCommand extends Command {
     try {
       const res = await ExchangeApi.getInstance().getExchange(from.toUpperCase(), to.toUpperCase());
       const total = (res.rates[to] * parseFloat(ammount)).toFixed(2);
+      const totalFormated = Intl.NumberFormat('pt-BR', { style: 'currency', currency: to}).format(total)
 
-      message.chinoReply('success', moneybag + ' ' + t('commands:money.success', { from, to, ammount, total }));
+      message.chinoReply('success', moneybag + ' ' + t('commands:money.success', { from, to, ammount, total: totalFormated }));
     } catch (err) {
       if (err instanceof InvalidArgumentError) {
         message.chinoReply('error',t('commands:money.invalidArgument', { arg: err.message }));

--- a/src/commands/Util/MoneyCommand.js
+++ b/src/commands/Util/MoneyCommand.js
@@ -37,7 +37,7 @@ class LeaveCommand extends Command {
     to = to.toUpperCase();
 
     try {
-      const res = await ExchangeApi.getInstance().getCurrency(from.toUpperCase(), to.toUpperCase());
+      const res = await ExchangeApi.getInstance().getExchange(from.toUpperCase(), to.toUpperCase());
       const total = (res.rates[to] * parseFloat(ammount)).toFixed(2);
 
       message.chinoReply('success', moneybag + ' ' + t('commands:money.success', { from, to, ammount, total }));

--- a/src/commands/Util/MoneyCommand.js
+++ b/src/commands/Util/MoneyCommand.js
@@ -1,0 +1,52 @@
+const Command = require("../../structures/command");
+const ExchangeApi = require('../../api/exchangeApi');
+const InvalidArgumentError = require('../../error/invalidArgumentError');
+
+class LeaveCommand extends Command {
+  constructor(client) {
+    super(client, {
+      name: 'money',
+      category: 'util',
+      aliases: ['bufunfa', 'currency', 'convercao'],
+      UserPermission: [],
+      ClientPermission: null,
+      OnlyDevs: false,
+      hidden: false,
+    })
+  }
+  async run({ message, args, server }, t) {
+    let [ from, to, ammount = 1 ] = args;
+
+    const { moneybag } = this.client.emotes;
+
+    if (!from || !to || (ammount === null)) {
+      message.chinoReply('error', t('commands:money.invalidOptions', {
+        prefix: server.prefix,
+        name: this.config.name,
+      }));
+
+      return;
+    }
+
+    if (isNaN(ammount)) {
+      message.chinoReply('error',t('command:money.invalidValue'))
+      return;
+    }
+
+    from = from.toUpperCase();
+    to = to.toUpperCase();
+
+    try {
+      const res = await ExchangeApi.getInstance().getCurrency(from.toUpperCase(), to.toUpperCase());
+      const total = (res.rates[to] * parseFloat(ammount)).toFixed(2);
+
+      message.chinoReply('success', moneybag + ' ' + t('commands:money.success', { from, to, ammount, total }));
+    } catch (err) {
+      if (err instanceof InvalidArgumentError) {
+        message.chinoReply('error',t('commands:money.invalidArgument', { arg: err.message }));
+      }
+    }
+  }
+}
+
+module.exports = LeaveCommand;

--- a/src/commands/Util/MoneyCommand.js
+++ b/src/commands/Util/MoneyCommand.js
@@ -14,6 +14,7 @@ class LeaveCommand extends Command {
       hidden: false,
     })
   }
+
   async run({ message, args, server }, t) {
     let [from, to, ammount = 1] = args;
 

--- a/src/commands/Util/MoneyCommand.js
+++ b/src/commands/Util/MoneyCommand.js
@@ -2,7 +2,7 @@ const Command = require("../../structures/command");
 const ExchangeApi = require('../../api/exchangeApi');
 const InvalidArgumentError = require('../../error/invalidArgumentError');
 
-class LeaveCommand extends Command {
+class MoneyCommand extends Command {
   constructor(client) {
     super(client, {
       name: 'money',
@@ -51,4 +51,4 @@ class LeaveCommand extends Command {
   }
 }
 
-module.exports = LeaveCommand;
+module.exports = MoneyCommand;

--- a/src/error/invalidArgumentError.js
+++ b/src/error/invalidArgumentError.js
@@ -1,0 +1,7 @@
+class InvalidArgumentError extends Error {
+  constructor(message) {
+    super(message)
+  }
+}
+
+module.exports = InvalidArgumentError;

--- a/src/locales/en-US/commands.json
+++ b/src/locales/en-US/commands.json
@@ -402,5 +402,11 @@
         "failure": "{{ type }} reload failed .Stack:\n ```js {{ rst  }} ```",
         "nonExistent": "{{ type }} nonexistend.",
         "success": "command reloaded successfully!"
+    },
+    "money": {
+        "invalidOptions": "command invalid!\n**Correct usage:**\t{{ prefix }}{{ name }} {from} {to} [ammount]\n**Example:**\t\t  {{ prefix }}{{ name }} BRL USD 1",
+        "invalidValue": "please give me a correct value!",
+        "invalidArgument":"invalid argument: {{ arg }}",
+        "success": "{{ ammount }} **{{ from }}** to **{{ to }}** = **{{ total }}**"
     }
 }

--- a/src/locales/pt-BR/commands.json
+++ b/src/locales/pt-BR/commands.json
@@ -485,7 +485,7 @@
     },
     "money": {
         "invalidOptions": "comando inválido!\n**Uso correto:**\t{{ prefix }}{{ name }} {de} {para} [quantidade]\n**Exemplo:**\t\t  {{ prefix }}{{ name }} BRL USD 1",
-        "invalidValue": "senpai por favor informe um valor correto!",
+        "invalidValue": "senpai, por favor informe um valor correto!",
         "invalidArgument":"argumento inválido: {{ arg }}",
         "success": "{{ ammount }} **{{ from }}** para **{{ to }}** = **{{ total }}**"
     }

--- a/src/locales/pt-BR/commands.json
+++ b/src/locales/pt-BR/commands.json
@@ -482,5 +482,11 @@
         "failure": "falha no recarregamento do {{ type }}.Stack:\n ```js {{ rst  }} ```",
         "nonExistent": "{{ type }} inexistente.",
         "success": "comando recarregado com sucesso!"
+    },
+    "money": {
+        "invalidOptions": "comando inválido!\n**Uso correto:**\t{{ prefix }}{{ name }} {de} {para} [quantidade]\n**Exemplo:**\t\t  {{ prefix }}{{ name }} BRL USD 1",
+        "invalidValue": "senpai por favor informe um valor correto!",
+        "invalidArgument":"argumento inválido: {{ arg }}",
+        "success": "{{ ammount }} **{{ from }}** para **{{ to }}** = **{{ total }}**"
     }
 }

--- a/src/locales/pt-PT/commands.json
+++ b/src/locales/pt-PT/commands.json
@@ -378,7 +378,7 @@
     },
     "money": {
         "invalidOptions": "comando inválido!\n**Uso correto:**\t{{ prefix }}{{ name }} {de} {para} [quantidade]\n**Exemplo:**\t\t  {{ prefix }}{{ name }} BRL USD 1",
-        "invalidValue": "senpai por favor informe um valor correto!",
+        "invalidValue": "senpai, por favor informe um valor correto!",
         "invalidArgument":"argumento inválido: {{ arg }}",
         "success": "{{ ammount }} **{{ from }}** para **{{ to }}** = **{{ total }}**"
     }

--- a/src/locales/pt-PT/commands.json
+++ b/src/locales/pt-PT/commands.json
@@ -375,5 +375,11 @@
         "failure": "falha no recarregamento do {{ type }}.Stack:\n ```js {{ rst  }} ```",
         "nonExistent": "{{ type }} inexistente.",
         "success": "comando recarregado com sucesso!"
+    },
+    "money": {
+        "invalidOptions": "comando inválido!\n**Uso correto:**\t{{ prefix }}{{ name }} {de} {para} [quantidade]\n**Exemplo:**\t\t  {{ prefix }}{{ name }} BRL USD 1",
+        "invalidValue": "senpai por favor informe um valor correto!",
+        "invalidArgument":"argumento inválido: {{ arg }}",
+        "success": "{{ ammount }} **{{ from }}** para **{{ to }}** = **{{ total }}**"
     }
 }


### PR DESCRIPTION
comando para fazer conversões monetárias.

O uso dele é:
`money (from) (to) [ammount]`
Quando não passado o ammount considera 1 como default.

Criei uma cache em memória que salva os valores pesquisados por durante 15 minutos (pode ser alterado por uma constante no arquivo exchangeApi.js) para não ficar fazendo requisição à API toda hora e agilizar o comando.