### PR TITLE
Fix security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "os": "^0.1.1",
     "parse-duration": "^0.1.2",
     "request": "^2.88.2",
+    "workerpool": "^6.0.0",
     "youtube-info": "^1.3.2"
   },
   "devDependencies": {

--- a/src/commands/util/CalculateCommand.js
+++ b/src/commands/util/CalculateCommand.js
@@ -1,5 +1,25 @@
 const Command = require("../../structures/command")
-let math = require("mathjs")
+const workerpool = require('workerpool');
+const pool = workerpool.pool();
+
+function calc (expr) {
+	const { create, all } = require('mathjs')
+	const math = create(all)
+	const limitedEvaluate = math.evaluate
+
+	math.import({
+		'import': 'Function import is disabled',
+		'createUnit': 'Function createUnit is disabled',
+		'evaluate': 'Function evaluate is disabled',
+		'parse': 'Function parse is disabled',
+		'simplify': 'Function simplify is disabled',
+		'derivative': 'Function derivative is disabled',
+		'format': 'Function format is disabled'
+	}, {override: true})
+
+	return limitedEvaluate(expr).toString()
+}
+
 module.exports = class CalculateCommand extends Command {
 	constructor(client) {
 		super(client, {
@@ -15,12 +35,9 @@ module.exports = class CalculateCommand extends Command {
 
 		let question = args.join(" ")
 		if (!question) return message.chinoReply("error", t("commands:calc.args-null"))
-		function calc(expression) {
-			'use strict';
-			return math.evaluate(expression)
-		}
-		let resposta = calc(question)
 
-		message.chinoReply("diamond", t("commands:calc.result", { resposta: resposta }))
+		pool.exec(calc, [question]).then((r) => message.chinoReply("diamond", t("commands:calc.result", { resposta: r })))
+			.catch((e) => message.chinoReply("error", t("commands:calc.result", { resposta: e.stack })))
+			.then(() => pool.terminate())
 	}
 }


### PR DESCRIPTION
This PR removes dangerous math.js functions (such as `createUnit`) and sandboxes the `evalute()` function, to avoid CPU-consuming operations from stopping the bot.