### PR TITLE
Limit of yens

### DIFF
--- a/src/commands/economy/PayCommand.js
+++ b/src/commands/economy/PayCommand.js
@@ -34,13 +34,13 @@ module.exports = class PayCommand extends Command {
 		let realValue = valuePorcent(value, 2)
 
 		message.chinoReply("warn", t("commands:pay.confirm", { value: Number(realValue[0]).toLocaleString(), member: member.toString(), porcent: realValue[1] })).then(msg => {
-			msg.react("👍")
-			setTimeout(() => msg.react("👎"), 1000)
+			msg.react("success:577973168342302771")
+			setTimeout(() => msg.react("error:577973245391667200"), 1000)
 
-			const collector = msg.createReactionCollector((reaction, user) => (reaction.emoji.name === "👍", "👎") && (user.id !== this.client.user.id && user.id === message.author.id))
+			const collector = msg.createReactionCollector((reaction, user) => (reaction.emoji.name === "success", "error") && (user.id !== this.client.user.id && user.id === message.author.id))
 			collector.on("collect", r => {
 				switch (r.emoji.name) {
-					case "👍":
+					case "success":
 						donator.yens = Number(value) -  donator.yens
 						membro.yens = membro.yens + Number(realValue[0])
 						if(membro.yens > 1000000000) return message.chinoReply("error", t("commands:pay.limit")), msg.delete();
@@ -50,7 +50,7 @@ module.exports = class PayCommand extends Command {
 						message.chinoReply("money_with_wings", t("commands:pay.success", { member: member.toString(), value: Number(realValue[0]).toLocaleString() }))
 						msg.delete()
 						break;
-					case "👎":
+					case "error":
 						message.chinoReply("error", t("commands:pay.cancel", { value: Number(realValue[0]).toLocaleString() }))
 						msg.delete()
 						break;

--- a/src/commands/economy/PayCommand.js
+++ b/src/commands/economy/PayCommand.js
@@ -34,22 +34,23 @@ module.exports = class PayCommand extends Command {
 		let realValue = valuePorcent(value, 2)
 
 		message.chinoReply("warn", t("commands:pay.confirm", { value: Number(realValue[0]).toLocaleString(), member: member.toString(), porcent: realValue[1] })).then(msg => {
-			msg.react("success:577973168342302771")
-			setTimeout(() => msg.react("error:577973245391667200"), 1000)
+			msg.react("👍")
+			setTimeout(() => msg.react("👎"), 1000)
 
-			const collector = msg.createReactionCollector((reaction, user) => (reaction.emoji.name === "success", "error") && (user.id !== this.client.user.id && user.id === message.author.id))
+			const collector = msg.createReactionCollector((reaction, user) => (reaction.emoji.name === "👍", "👎") && (user.id !== this.client.user.id && user.id === message.author.id))
 			collector.on("collect", r => {
 				switch (r.emoji.name) {
-					case "success":
-						donator.yens = donator.yens - Number(value)
+					case "👍":
+						donator.yens = Number(value) -  donator.yens
 						membro.yens = membro.yens + Number(realValue[0])
+						if(membro.yens > 1000000000) return message.chinoReply("error", t("commands:pay.limit")), msg.delete();
 						membro.save()
 						donator.save()
 
 						message.chinoReply("money_with_wings", t("commands:pay.success", { member: member.toString(), value: Number(realValue[0]).toLocaleString() }))
 						msg.delete()
 						break;
-					case "error":
+					case "👎":
 						message.chinoReply("error", t("commands:pay.cancel", { value: Number(realValue[0]).toLocaleString() }))
 						msg.delete()
 						break;

--- a/src/locales/en-US/commands.json
+++ b/src/locales/en-US/commands.json
@@ -292,6 +292,7 @@
     },
     "ping": "I have:",
     "pay": {
+        "limit": "This account has exceeded the **yen limit**!",
         "value-null": "you need to enter the amount you wish to donate.",
         "invalid-value": "the value you entered is invalid.",
         "insufficient-value": "you don't have enough yens.",

--- a/src/locales/en-US/commands.json
+++ b/src/locales/en-US/commands.json
@@ -292,7 +292,7 @@
     },
     "ping": "I have:",
     "pay": {
-        "limit": "This account has exceeded the **yen limit**!",
+        "limit": "This amount has exceeded the **yen limit**!",
         "value-null": "you need to enter the amount you wish to donate.",
         "invalid-value": "the value you entered is invalid.",
         "insufficient-value": "you don't have enough yens.",

--- a/src/locales/es/commands.json
+++ b/src/locales/es/commands.json
@@ -278,6 +278,7 @@
     },
     "ping": "Eu tenho:",
     "pay": {
+        "limit": "Esta conta excedeu o **limite de yens**",
         "value-null": "você precisa informar a quantidade que você deseja doar.",
         "invalid-value": "o valor informado é inválido.",
         "insufficient-value": "você não tem yens o suficiente.",

--- a/src/locales/es/commands.json
+++ b/src/locales/es/commands.json
@@ -278,7 +278,7 @@
     },
     "ping": "Eu tenho:",
     "pay": {
-        "limit": "Esta conta excedeu o **limite de yens**",
+        "limit": "Esta transferência excedeu o **limite de yens**",
         "value-null": "você precisa informar a quantidade que você deseja doar.",
         "invalid-value": "o valor informado é inválido.",
         "insufficient-value": "você não tem yens o suficiente.",

--- a/src/locales/pt-BR/commands.json
+++ b/src/locales/pt-BR/commands.json
@@ -339,6 +339,7 @@
     },
     "ping": "Eu tenho:",
     "pay": {
+        "limit": "Esta conta excedeu o **limite de yens**",
         "confirm": "o usuário {{member}} irá receber `{{value}}` yens, deseja continuar com a transação? Ao continuar, eu irei cobrar `{{porcent}}%` de taxa.",
         "value-null": "você precisa informar a quantidade que você deseja doar.",
         "invalid-value": "o valor informado é inválido.",

--- a/src/locales/pt-BR/commands.json
+++ b/src/locales/pt-BR/commands.json
@@ -339,7 +339,7 @@
     },
     "ping": "Eu tenho:",
     "pay": {
-        "limit": "Esta conta excedeu o **limite de yens**",
+        "limit": "Esta transferência excedeu o **limite de yens**",
         "confirm": "o usuário {{member}} irá receber `{{value}}` yens, deseja continuar com a transação? Ao continuar, eu irei cobrar `{{porcent}}%` de taxa.",
         "value-null": "você precisa informar a quantidade que você deseja doar.",
         "invalid-value": "o valor informado é inválido.",

--- a/src/locales/pt-PT/commands.json
+++ b/src/locales/pt-PT/commands.json
@@ -177,6 +177,7 @@
     },
     "ping": "Eu tenho:",
     "pay": {
+        "limit": "Esta conta excedeu o **limite de yens**",
         "value-null": "você precisa informar a quantidade que você deseja doar.",
         "invalid-value": "o valor informado é inválido.",
         "insufficient-value": "você não tem yens o suficiente.",


### PR DESCRIPTION
I added `if()` to limit the amount of yen for when adding results calculated to not form an infinite value. Recent Javascript updates are returning an infinite value **(Symbol ∞)** that there are no methods for capturing numbers that are in that infinite value.

**Locales:**
Has added a translation of the yen limit on locales


**Screenshots:**
![test](https://user-images.githubusercontent.com/43297329/93419122-57c22680-f882-11ea-95cd-3d641b72c008.png)
